### PR TITLE
DM-12182: use calibration lookup and add internal directory structure

### DIFF
--- a/wcl/hsc_test_hscmini.wcl
+++ b/wcl/hsc_test_hscmini.wcl
@@ -43,7 +43,7 @@ verify_files = False
 # different blocks can have different job parallelism
 <block>
     <processccd>
-        modulelist = processccd
+        modulelist = query_processccd, processccd
         divide_jobs_by = ccd, filter
     </processccd>
     <drp-patch>
@@ -56,6 +56,15 @@ verify_files = False
 </block>
 
 <module>
+    <query_processccd>
+        noop = True
+        <list>
+            <allfiles>
+                exec = processccd_query.py
+                args = --section ${submit_des_db_section} --qoutfile ${qoutfile} --tract ${tract} --overlap_version ${overlap_version} --calib_version ${calib_version}
+            </allfiles>
+        </list>
+    </query_processccd>
     <processccd>
         <exec_1>
             execname = processCcd.py
@@ -77,39 +86,20 @@ verify_files = False
         </exec_1>
         <file>
             <biascor>
-                query_table = calibration
-                join calibration.filename=ops_calibration_lookup.filename
-                query_fields = filetype, ops_calibration_lookup.version
-                version = ${calib_version}
-                filetype = cal_biascor_hsc
-                output_fields = filename, calib_date, ccd
-                match = ccd
-
+                depends query_processccd.list.allfiles.cal_biascor_hsc
+                match = imgname
                 dirpat = lsst_calib
                 calibtype = BIAS
             </biascor>
             <dflatcor>
-                query_table = calibration
-                join calibration.filename=ops_calibration_lookup.filename
-                query_fields = filetype, ops_calibration_lookup.version
-                version = ${calib_version}
-                filetype = cal_dflatcor_hsc
-                output_fields = filename, calib_date, filter, ccd
-                match = filter, ccd
-
-                #BROKEN filename = FLAT-${calibdate}-${filter}-${ccd:3}.fits
+                depends query_processccd.list.allfiles.cal_dflatcor_hsc
+                match = imgname
                 dirpat = lsst_calib_filter
                 calibtype = FLAT
             </dflatcor>
             <darkcor>
-                query_table = calibration
-                join calibration.filename=ops_calibration_lookup.filename
-                query_fields = filetype, ops_calibration_lookup.version
-                version = ${calib_version}
-                filetype = cal_darkcor_hsc
-                output_fields = filename, calib_date, ccd
-                match = ccd
-
+                depends query_processccd.list.allfiles.cal_darkcor_hsc
+                match = imgname
                 dirpat = lsst_calib
                 calibtype = DARK
             </darkcor>
@@ -119,19 +109,8 @@ verify_files = False
                 job_enddir = CALIB/BFKERNEL
             </bf>
             <raw>
-                # how to get data
-                exec = hsc_dummy_query_raw.py
-                #args = --qoutfile ${qoutfile} --tract ${tract} --tractinfo ${tractinfo} --section ${submit_des_db_section}
-                args = --qoutfile ${qoutfile} --tract ${tract} --section ${submit_des_db_section} --overlap_version ${overlap_version}
-                #query_table = image
-                #query_fields = filetype, overlap.tract
-                #join = image.visit=overlap.visit, image.ccd=overlap.ccd
-                filetype = hsc_raw
-                #output_fields = filename,visit,filter,ccd,pointing,overlap.tract,field,dateobs
-                output_fields = filename,visit,filter,ccd,pointing,tract,field,dateobs
-
-                #
-                match = visit, filter, ccd, pointing
+                depends query_processccd.list.allfiles.raw
+                match = imgname, visit, filter, ccd, pointing
 
                 # how to put files in job scratch directory
                 dirpat = hsc_raw
@@ -330,7 +309,7 @@ verify_files = False
             ref_cats_root = ${ref_cats_path}
         </wrapper>
         wrappername = genwrap_lsst.py
-        wrapperloop = visit,filter,ccd, pointing   # filter included here so can match dflatcor on it (pointing for output paths)
+        wrapperloop = imgname,visit,filter,ccd,pointing   # filter included here so can match dflatcor on it (pointing for output paths)
         loopobj = file.raw   # what file to use to determine wrapper loop values
         modnamepat = ${modnamepat_tract_visit_ccd_filter}
     </processccd>

--- a/wcl/hsc_test_hscmini.wcl
+++ b/wcl/hsc_test_hscmini.wcl
@@ -312,6 +312,7 @@ verify_files = False
         wrapperloop = imgname,visit,filter,ccd,pointing   # filter included here so can match dflatcor on it (pointing for output paths)
         loopobj = file.raw   # what file to use to determine wrapper loop values
         modnamepat = ${modnamepat_tract_visit_ccd_filter}
+        end_mod_dir = ${modulename}/${filter}/${visit}
     </processccd>
     <make_coadd_temp_exp>
         <exec_1>  # label telling wrapper that this is the 1st exec to run
@@ -443,6 +444,7 @@ verify_files = False
         wrapperloop = tract,patch,visit,filter   # define_quanta (how many times to we run this)
         loopobj = list.corr   # what data is used along with wrapperloop
         modnamepat = ${modnamepat_tract_patch_visit_filter}  # how to name internal files like wrapper wcl and log files
+        end_mod_dir = ${modulename}/${patch}/${filter}
     </make_coadd_temp_exp>
     <assemble_coadd>
         <exec_1>
@@ -582,6 +584,7 @@ verify_files = False
                 rundir = list/${modulename}
             </tempexp>
         </list>
+        end_mod_dir = ${modulename}/${patch}/${filter}
     </assemble_coadd>
     <detect_coadd_sources>
         <exec_1>
@@ -719,6 +722,7 @@ verify_files = False
                 job_outtype = detectCoaddSources_metadata
             </detectcoaddsources_md_boost>
         </file>
+        end_mod_dir = ${modulename}/${patch}/${filter}
     </detect_coadd_sources>
     <merge_coadd_detections>
         <exec_1>
@@ -835,6 +839,7 @@ verify_files = False
                 rundir = list/${modulename}
             </det>
         </list>
+        end_mod_dir = ${modulename}/${patch}/
     </merge_coadd_detections>
     <measure_coadd_sources>
         <exec_1>
@@ -1022,6 +1027,7 @@ verify_files = False
                 job_outtype = measureCoaddSources_metadata
             </measurecoaddsources_md_boost>
         </file>
+        end_mod_dir = ${modulename}/${patch}/${filter}
     </measure_coadd_sources>
     <merge_coadd_measurements>
         <exec_1>
@@ -1123,6 +1129,7 @@ verify_files = False
                 rundir = list/${modulename}
             </meas>
         </list>
+        end_mod_dir = ${modulename}/${patch}/
     </merge_coadd_measurements>
     <forced_phot_coadd>
         <exec_1>
@@ -1246,6 +1253,7 @@ verify_files = False
                 job_outtype = deepCoadd_forced_metadata
             </forcedphotcoadd_md_boost>
         </file>
+        end_mod_dir = ${modulename}/${patch}/${filter}
     </forced_phot_coadd>
     <forced_phot_ccd>
     # NOTE: forced_phot_ccd does not work yet and is not included in mini test
@@ -1351,6 +1359,7 @@ verify_files = False
                 job_endir = tract${tract}
             </forced_src>
         </file>
+        end_mod_dir = ${modulename}/${filter}/${visit}
     </forced_phot_ccd>
 </module>
 
@@ -1699,6 +1708,28 @@ verify_files = False
         ops = ${ops_run_dir}/${ops_enddir}
         runtime = ${job_enddir}
     </generic_norepo>
+    #####  trying new internal file directory patterns due to too many files in 1 dir
+    <inputwcl>
+        name = wcl
+        ops = ${ops_run_dir}/inputwcl/${end_mod_dir}
+        runtime = inputwcl/${end_mod_dir}
+    </inputwcl>
+    <outputwcl>
+        name = wcl
+        ops = ${ops_run_dir}/outputwcl/${end_mod_dir}
+        runtime = outputwcl/${end_mod_dir}
+    </outputwcl>
+    <list>
+        name = list
+        ops = ${ops_run_dir}/list/${end_mod_dir}
+        runtime = list/${end_mod_dir}
+    </list>
+    <log>
+        name = log
+        ops = ${ops_run_dir}/log/${end_mod_dir}
+        runtime = log/${end_mod_dir}
+    </log>
+    # need to keep an eye on junkdir to see if overload with files (i.e., what is max # of condor jobs?)
 </directory_pattern>
 
 modnamepat_tract_generic = ${unitname}-r${reqnum}p${attnum:2}_${modulename}


### PR DESCRIPTION
- Use the new calibration lookup query
- Add internal file directory patterns to inputwcl, outputwcl, list, and log