### PR TITLE
DM-12240: Fix the misplaced  calibRegistry.sqlite3

### DIFF
--- a/wcl/drp_modules.wcl
+++ b/wcl/drp_modules.wcl
@@ -16,7 +16,7 @@ verify_files = False
         <list>
             <allfiles>
                 exec = processccd_query.py
-                args = --section ${submit_des_db_section} --qoutfile ${qoutfile} --tract ${tract} --overlap_version ${overlap_version} --calib_version ${calib_version} --filter ${filter_nofringe} --visittag ${visit_tag}
+                args = --section ${submit_des_db_section} --qoutfile ${qoutfile} --tract ${tract} --overlap_version ${overlap_version} --calib_version ${calib_version} --filter ${filter_nofringe} $opt{visit_tag}
             </allfiles>
         </list>
     </query_processccd_nofringe>
@@ -274,7 +274,7 @@ verify_files = False
         <list>
             <allfiles>
                 exec = processccd_query.py
-                args = --section ${submit_des_db_section} --qoutfile ${qoutfile} --tract ${tract} --overlap_version ${overlap_version} --calib_version ${calib_version} --filter ${filter_fringe} --visittag ${visit_tag}
+                args = --section ${submit_des_db_section} --qoutfile ${qoutfile} --tract ${tract} --overlap_version ${overlap_version} --calib_version ${calib_version} --filter ${filter_fringe} $opt{visit_tag}
             </allfiles>
         </list>
     </query_processccd_fringe>

--- a/wcl/drp_modules.wcl
+++ b/wcl/drp_modules.wcl
@@ -102,7 +102,7 @@ verify_files = False
                 # where to put it (jobroot=rundir, archive=ops_enddir)
                 rename_file = calibRegistry.sqlite3
                 dirpat = generic_norepo
-                job_enddir = ${job_repo_dir}
+                job_enddir = ${job_repo_dir}/CALIB
             </butler_registry_calib>
             <butler_template>
                 # how to name input file
@@ -366,7 +366,7 @@ verify_files = False
                 # where to put it (jobroot=rundir, archive=ops_enddir)
                 rename_file = calibRegistry.sqlite3
                 dirpat = generic_norepo
-                job_enddir = ${job_repo_dir}
+                job_enddir = ${job_repo_dir}/CALIB
             </butler_registry_calib>
             <butler_template>
                 # how to name input file

--- a/wcl/hsc_test_hscfringe.wcl
+++ b/wcl/hsc_test_hscfringe.wcl
@@ -15,7 +15,7 @@ pipever = w_2017_33_v1
 
 filter_fringe = HSC-Y,NB0921
 filter_nofringe = HSC-G,HSC-I,HSC-R,HSC-Z
-visit_tag = minifringe
+visit_tag = --visittag minifringe
 
 dataset = hsc               # used in names of butler registry files
 overlap_version = hsc-v1

--- a/wcl/hsc_test_hscmini.wcl
+++ b/wcl/hsc_test_hscmini.wcl
@@ -15,7 +15,7 @@ pipever = w_2017_33_v1
 
 filter_fringe = HSC-Y,NB0921
 filter_nofringe = HSC-G,HSC-I,HSC-R,HSC-Z
-visit_tag = ci_hsc
+#visit_tag = --visittag ci_hsc  # visittag is not necessary as it includes the entire "ci_hsc" dataset
 
 dataset = ci_hsc               # used in names of butler registry files
 overlap_version = minihsc-v2


### PR DESCRIPTION
Otherwise Butler is unable to locate the sqlite3 file in the expected place and create a Posix registry to perform data lookups.  Using Posix registry unintentionally can result in errors in some cases. 